### PR TITLE
Adding vertical z axes & z label closer

### DIFF
--- a/R/volcano3D.R
+++ b/R/volcano3D.R
@@ -327,13 +327,13 @@ volcano3D <- function(polar,
             textposition = 'middle center', 
             hoverinfo = 'none', showlegend = FALSE, inherit = FALSE) %>%
         
-        # label z axis
+        # label z axis and draw three vertical axes
         add_text(x = c(rep(1.05*R*sinpi(axis_angle), 
                            grid@n_z_breaks), 
-                       1.2*R*z_axis_title_offset*sinpi(axis_angle)),
+                       1.2*R*sinpi(axis_angle)),
                  y = c(rep(1.05*R*cospi(axis_angle), 
                            grid@n_z_breaks), 
-                       1.2*R*z_axis_title_offset*cospi(axis_angle)),
+                       1.2*R*cospi(axis_angle)),
                  z = c(grid@z_breaks, h/2)*0.95,
                  text = c(grid@z_breaks, '-log<sub>10</sub>P'),
                  textposition = 'middle left', 
@@ -345,6 +345,20 @@ volcano3D <- function(polar,
                   z = c(0, h), color = I(axis_colour),
                   line = list(width = axis_width), 
                   showlegend = FALSE, type = "scatter3d", mode = "lines",
+                  hoverinfo = "none", inherit = FALSE) %>%
+  
+        add_trace(x = R * sin(pi*axis_angle + 2.0944),
+                y = R * cos(pi*axis_angle + 2.0944),
+                z = c(0, h),
+                color = I(axis_colour), line = list(width = axis_width),
+                showlegend = FALSE, type = "scatter3d", mode = "lines", 
+                hoverinfo = "none", inherit = FALSE) %>%
+  
+        add_trace(x = R * sin(pi*axis_angle + 2.0944 + 2.0944),
+                  y = R * cos(pi*axis_angle + 2.0944 + 2.0944),
+                  z = c(0, h), color = I(axis_colour),
+                  line = list(width = axis_width), showlegend = FALSE,
+                  type = "scatter3d", mode = "lines",
                   hoverinfo = "none", inherit = FALSE) %>%
         
         # label radial axis

--- a/R/volcano3D.R
+++ b/R/volcano3D.R
@@ -282,7 +282,7 @@ volcano3D <- function(polar,
             if(colour_code_labels) ac <- row$col else ac <- label_colour 
             annot <- list(x = row$x, y = row$y, z = row$logP, text = row$label, 
                           textangle = 0, ax = arrow_length, ay  = 0,
-                          arrowcolor = ac, font = list(color = ac),
+                          arrowcolor = ac, font = list(size = label_size, color = ac),
                           arrowwidth = 1, arrowhead = 6, arrowsize = 1.5, 
                           yanchor = "middle")
         })


### PR DESCRIPTION
Hi Kat, 

Here two suggestions about the volcano3D: 
- I've added two more vertical black lines to delineate the three axes, this comes from one of Myles' comments and I think it's nice
- I've moved the '-logP' label closer to the axis. I know that this makes the label overlap with z numbers in the first preview but when you zoom in it looks too far. Of course you might want to leave it as it is. 

Below an example of the result: 

![Cattura](https://user-images.githubusercontent.com/70027703/135885153-f20784ef-d266-444f-b3d1-dc716591f8e7.PNG)
 